### PR TITLE
chore(research): excluding unused fields from /api/articles endpoint

### DIFF
--- a/server/apps/research/serializers/__init__.py
+++ b/server/apps/research/serializers/__init__.py
@@ -1,3 +1,3 @@
 from .author_serializer import AuthorSerializer
 from .category_serializer import CategorySerializer
-from .article_serializer import ArticleSerializer, ArticleCreateUpdateSerializer
+from .article_serializer import ArticleSerializer, ArticleCreateUpdateSerializer, ArticleListSerializer

--- a/server/apps/research/serializers/article_serializer.py
+++ b/server/apps/research/serializers/article_serializer.py
@@ -3,6 +3,17 @@ from ..models import Article, Author, Category
 from .author_serializer import AuthorSerializer
 from .category_serializer import CategorySerializer
 
+class ArticleListSerializer(serializers.ModelSerializer):
+    categories = CategorySerializer(many=True)
+
+    class Meta:
+        model = Article
+        include = ['categories']
+        exclude = [
+            'content', 'authors', 'scheduled_publish_time', 'acknowledgement', 
+            'status', 'views', 'created_at', 'updated_at'
+        ]
+
 class ArticleSerializer(serializers.ModelSerializer):
     """Serializer for the Article model."""
     authors = AuthorSerializer(many=True, read_only=True)

--- a/server/apps/research/views.py
+++ b/server/apps/research/views.py
@@ -7,7 +7,7 @@ import uuid
 
 from .models import Article
 from .permissions import ArticleUserWritePermission
-from .serializers import ArticleSerializer, ArticleCreateUpdateSerializer
+from .serializers import ArticleSerializer, ArticleCreateUpdateSerializer, ArticleListSerializer
 
 def index(request):
     return render(request, 'index.html')
@@ -19,6 +19,8 @@ class ArticleViewSet(viewsets.ModelViewSet):
     
     def get_serializer_class(self):
         """Return appropriate serializer class based on request method."""
+        if self.action == 'list':
+            return ArticleListSerializer
         if self.request.method in ['POST', 'PUT', 'PATCH']:
             return ArticleCreateUpdateSerializer
         return ArticleSerializer


### PR DESCRIPTION
By not returning the article's `content`, we're able to improve the UI loading time significantly since the payload being trasnported is smaller.

Also removed everything that's not being used by the UI when it fetchs the list of all articles. If needed, in the future we can reintroduce the ones required