### PR TITLE
chore(fix): admin can create author without signing-in to author profile

### DIFF
--- a/server/apps/research/admin/author_admin.py
+++ b/server/apps/research/admin/author_admin.py
@@ -13,7 +13,5 @@ class AuthorAdmin(admin.ModelAdmin):
     search_fields = ('user__username', 'twitter_username')
     
     def save_model(self, request, obj, form, change):
-        """Automatically set the author to the logged-in user when creating a new author."""
-        if not change:  # If creating a new author
-            obj.user = request.user  
+        """Save the model instance to the database."""
         super().save_model(request, obj, form, change)


### PR DESCRIPTION

Before: Admin have to log in to a new user's account before an author profile can be created.
Now: Admin can create a new user with the corresponding author profile without signing-in to the user's profile. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed automatic user assignment when creating a new author instance.
  
- **Documentation**
	- Updated docstring for the `save_model` method to reflect changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->